### PR TITLE
Workarounds/fixes/improvement for flickering on display @32bpp when using DMA2D

### DIFF
--- a/libraries/agfx/examples/agfx_test/agfx_test.ino
+++ b/libraries/agfx/examples/agfx_test/agfx_test.ino
@@ -9,30 +9,47 @@ void setup()
 
 void loop()
 {
+    agfx.showScreen(0);
+    agfx.setDrawScreen(0);
     agfx.fill(AGFX_WHITE);
 
+    agfx.setDrawScreen(1);
     agfx.background(AGFX_WHITE);
+    agfx.showScreen(1);
     agfx.demoLine(2);
     delay(1000);
 
+    agfx.setDrawScreen(0);
     agfx.background(AGFX_WHITE);
     agfx.demoPolygon();
+    agfx.showScreen(0);
     delay(2000);
 
+    agfx.setDrawScreen(1);
     agfx.background(AGFX_WHITE);
     agfx.demoCircle();
+    agfx.showScreen(1);
     delay(2000);
 
+    agfx.setDrawScreen(0);
     agfx.background(AGFX_WHITE);
     agfx.demoEllipse();
+    agfx.showScreen(0);
     delay(2000);
 
-    agfx.background(AGFX_WHITE);
+    // Copy shown screen to hidden screen and add some text
+    agfx.setDrawScreen(1);
+    agfx.copyScreen(0, 1);
     agfx.demoText();
+    agfx.showScreen(1);
     delay(3000);
 
-    // Blocking demo
+    agfx.setDrawScreen(0);
     agfx.background(AGFX_WHITE);
-    agfx.demoTouch();
+    agfx.showScreen(0);
+
+    // Blocking demo
+    //agfx.background(AGFX_WHITE);
+    //agfx.demoTouch();
 }
 

--- a/libraries/agfx/src/agfx.cpp
+++ b/libraries/agfx/src/agfx.cpp
@@ -71,6 +71,26 @@ bool AGFX::begin()
     return true;
 }
 
+void AGFX::setDrawScreen(uint8_t scrIdx)
+{
+    STAR_DSI_SetDrawScreen(scrIdx);
+}
+
+uint8_t AGFX::getDrawScreen(void)
+{
+    return STAR_DSI_GetDrawScreen();
+}
+
+void AGFX::showScreen(uint8_t scrIdx)
+{
+    STAR_DSI_ShowScreen(scrIdx);
+}
+
+void AGFX::copyScreen(uint8_t fromScrIdx, uint8_t toScrIdx)
+{
+    STAR_DSI_CopyScreen(fromScrIdx, toScrIdx);
+}
+
 // Processing stype API ------------------- BEGIN --------------------
 uint32_t AGFX::color(uint8_t r, uint8_t g, uint8_t b, uint8_t alpha)
 {

--- a/libraries/agfx/src/agfx.h
+++ b/libraries/agfx/src/agfx.h
@@ -12,6 +12,10 @@ class AGFX
 public:
     AGFX();
     bool begin();
+    void setDrawScreen(uint8_t scrIdx);
+    uint8_t getDrawScreen(void);
+    void showScreen(uint8_t scrIdx);
+    void copyScreen(uint8_t fromScrIdx, uint8_t toScrIdx);
     uint32_t color(uint8_t r, uint8_t g, uint8_t b, uint8_t alpha);
     uint32_t color(uint8_t r, uint8_t g, uint8_t b);
     uint32_t color(uint8_t gray, uint8_t alpha);

--- a/libraries/agfx/src/star_dsi.c
+++ b/libraries/agfx/src/star_dsi.c
@@ -1,8 +1,8 @@
 #include "star_dsi.h"
 #include "stm32f469xx.h"
 
+#define ENABLE_LTDC_IRQ
 // Not used yet
-//#define ENABLE_LTDC_IRQ
 //#define ENABLE_DMA2D_IRQ
 //#define ENABLE_DSI_IRQ
 
@@ -15,13 +15,17 @@
 //#define DMA2D_ARGB4444                       ((uint32_t)0x00000004)             /*!< ARGB4444 DMA2D color mode */
 
 // Valid only for 800x480 32bpp
+#define SCR_SIZE                        ((uint32_t)0x00180000) // slightly larger than 800*480*4
+#define MAX_SCR_COUNT                   2
 #define BG_LAYER_ADDR                   ((uint32_t)0xC0000000)
 #define BG_LAYER_IDX                    ((uint32_t)0)
 //#define FG_LAYER_IDX                    ((uint32_t)1)
 //#define NUM_LAYERS                      ((uint32_t)2)
 #define LCD_OTM8009A_ID                 ((uint32_t)0)
-#define FB_ADDR(_x, _y) \
-    (hltdc.LayerCfg[currLayer].FBStartAdress + 4*(panelWidth*(_y)+(_x)))
+#define FB_ADDR(_currScrIdx,_x, _y) \
+    (hltdc.LayerCfg[currLayer].FBStartAdress \
+     + _currScrIdx*SCR_SIZE \
+     + 4*(panelWidth*(_y)+(_x)))
 #define MIN(_a, _b)          ( (_a) > (_b) ? (_b) : (_a) )
 #define DMA2D_MAX_SIZE   128U
 #define DMA2D_MAX_AREA   (DMA2D_MAX_SIZE*DMA2D_MAX_SIZE)
@@ -38,6 +42,8 @@
 //#endif
 
 static uint32_t currLayer = BG_LAYER_IDX;
+static uint32_t currScrIdx = 0;
+static volatile uint8_t swapScrBuf = 0;
 static DSI_VidCfgTypeDef hdsivid;
 static DMA2D_HandleTypeDef hdma2d;
 static LTDC_HandleTypeDef hltdc;
@@ -110,6 +116,16 @@ void __irq_LTDC_ER_IRQHandler(void)
 
 void HAL_LTDC_LineEventCallback(LTDC_HandleTypeDef *hltdc)
 {
+    static uint32_t cnt = 0;
+
+    if (swapScrBuf) {
+        uint32_t addr = hltdc->LayerCfg[currLayer].FBStartAdress;
+        addr += currScrIdx * SCR_SIZE;
+        LTDC_LAYER(hltdc, currLayer)->CFBAR = addr;
+        __HAL_LTDC_RELOAD_CONFIG(hltdc);
+        swapScrBuf = 0;
+    }
+
     HAL_LTDC_ProgramLineEvent(hltdc, 0);
 }
 
@@ -308,9 +324,38 @@ uint16_t STAR_DSI_PanelHeight(void)
     return panelHeight;
 }
 
+void STAR_DSI_SetDrawScreen(uint8_t scrIdx)
+{
+    if (scrIdx < MAX_SCR_COUNT)
+        currScrIdx = scrIdx;
+}
+
+uint8_t STAR_DSI_GetDrawScreen(void)
+{
+    return currScrIdx;
+}
+
+void STAR_DSI_ShowScreen(uint8_t scrIdx)
+{
+    // Flip screen at next VSYNC
+    swapScrBuf = 1;
+    while (swapScrBuf) ;
+}
+
+void STAR_DSI_CopyScreen(uint8_t fromIdx, uint8_t toIdx)
+{
+    uint32_t offset = 0;
+
+    while (offset < SCR_SIZE) {
+        while (!IS_VBLANK()) ;
+        memcpy(FB_ADDR(toIdx, 0, 0)+offset, FB_ADDR(fromIdx, 0, 0)+offset, DMA2D_MAX_AREA);
+        offset += DMA2D_MAX_AREA;
+    }
+}
+
 void STAR_DSI_DrawPoint(uint16_t x, uint16_t y, uint32_t color)
 {
-    *(__IO uint32_t*)FB_ADDR(x, y) = color;
+    *(__IO uint32_t*)FB_ADDR(currScrIdx, x, y) = color;
 }
 
 static void STAR_DSI_FillBufferDma(uint32_t layerIdx, void *dst, uint32_t width,
@@ -345,7 +390,7 @@ void STAR_DSI_FillRectDma(uint16_t x, uint16_t y, uint16_t width,
             th = MIN(DMA2D_MAX_SIZE, rh);
             while (rw) {
                 tw = MIN(DMA2D_MAX_SIZE, rw);
-                STAR_DSI_FillBufferDma(currLayer, FB_ADDR(tx, ty), tw, th,
+                STAR_DSI_FillBufferDma(currLayer, FB_ADDR(currScrIdx, tx, ty), tw, th,
                         panelWidth - tw, color);
                 tx += DMA2D_MAX_SIZE;
                 rw -= tw;
@@ -357,7 +402,7 @@ void STAR_DSI_FillRectDma(uint16_t x, uint16_t y, uint16_t width,
         }
     }
     else {
-        STAR_DSI_FillBufferDma(currLayer, FB_ADDR(x, y), width, height,
+        STAR_DSI_FillBufferDma(currLayer, FB_ADDR(currScrIdx, x, y), width, height,
                 panelWidth - width, color);
     }
 }

--- a/libraries/agfx/src/star_dsi.h
+++ b/libraries/agfx/src/star_dsi.h
@@ -30,8 +30,6 @@ extern uint8_t STAR_DSI_Init(LCD_OrientationTypeDef orientation);
 extern uint16_t STAR_DSI_PanelWidth(void);
 extern uint16_t STAR_DSI_PanelHeight(void);
 extern void STAR_DSI_DrawPoint(uint16_t x, uint16_t y, uint32_t color);
-extern void STAR_DSI_FillBufferDma(uint32_t layerIdx, void *dst,
-        uint32_t width, uint32_t height, uint32_t lineOffset, uint32_t color);
 extern void STAR_DSI_FillRectDma(uint16_t x, uint16_t y, uint16_t width,
         uint16_t height, uint32_t color);
 extern void STAR_DSI_DisplayOn(void);

--- a/libraries/agfx/src/star_dsi.h
+++ b/libraries/agfx/src/star_dsi.h
@@ -29,6 +29,10 @@ extern void DSI_IO_WriteCmd(uint32_t NbrParams, uint8_t *pParams);
 extern uint8_t STAR_DSI_Init(LCD_OrientationTypeDef orientation);
 extern uint16_t STAR_DSI_PanelWidth(void);
 extern uint16_t STAR_DSI_PanelHeight(void);
+extern void STAR_DSI_SetDrawScreen(uint8_t scrIdx);
+extern uint8_t STAR_DSI_GetDrawScreen(void);
+extern void STAR_DSI_ShowScreen(uint8_t scrIdx);
+extern void STAR_DSI_CopyScreen(uint8_t fromIdx, uint8_t toIdx);
 extern void STAR_DSI_DrawPoint(uint16_t x, uint16_t y, uint32_t color);
 extern void STAR_DSI_FillRectDma(uint16_t x, uint16_t y, uint16_t width,
         uint16_t height, uint32_t color);


### PR DESCRIPTION
Added/fixed code for LTDC,DMA2D and DSI irq management (still disabled) and misc code cleanup.

Sync DMA2D to VSYNC and split large area request into smaller ones.

Added double buffering support (2 screens) and helper functions to select screen to drow to (visible or hidden), to select which screen to show and to copy framebuffer data from one screen to another; Updated example agfx_test.ino to reflect changes.

